### PR TITLE
Fix a private-in-public error

### DIFF
--- a/src/poly.rs
+++ b/src/poly.rs
@@ -255,7 +255,7 @@ impl<VIn, VOut,
     }
 }
 
-struct MapToVerticesIter<SRC, T, U, F: FnMut(T) -> U> {
+pub struct MapToVerticesIter<SRC, T, U, F: FnMut(T) -> U> {
     src: SRC,
     f: F,
     phantom_t: PhantomData<T>,


### PR DESCRIPTION
Not sure if this crate is abandoned or not, but it was broken by a bugfix in rustc (see https://tools.taskcluster.net/task-inspector/#VaCH8RmaTce-GCfHXWrWDA/0 and rust-lang/rust#34537 for more details).
Here's a fix.